### PR TITLE
Fix - accepting any string value for `trackID` 

### DIFF
--- a/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
+++ b/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
@@ -13,23 +13,22 @@ final class StreamSourceBuilder {
     }
 
     struct TrackItem {
-        let trackType: StreamSource.TrackType
+        let trackID: String
         let mediaType: StreamSource.MediaType
 
         /// Initialises the Track Item, if possible from the passed-in String
-        /// - Parameter track: A string value passed in by the SDK and is expected to be of format `{mediaType}/{trackType}`
+        /// - Parameter track: A string value passed in by the SDK and is expected to be of format `{mediaType}/{trackID}`
         init?(track: String) {
             let trackInfoList = track.split(separator: "/")
 
             guard
                 trackInfoList.count == 2,
-                let mediaType = StreamSource.MediaType(rawValue: String(trackInfoList[0])),
-                let trackType = StreamSource.TrackType(rawValue: String(trackInfoList[1]))
+                let mediaType = StreamSource.MediaType(rawValue: String(trackInfoList[0].lowercased()))
             else {
                 return nil
             }
             self.mediaType = mediaType
-            self.trackType = trackType
+            self.trackID = String(trackInfoList[1])
         }
     }
 
@@ -65,9 +64,10 @@ final class StreamSourceBuilder {
         audioTracks.append(
             StreamSource.AudioTrackInfo(
                 mid: mid,
-                trackType: trackItem.trackType,
+                trackID: trackItem.trackID,
                 mediaType: trackItem.mediaType,
-                track: track)
+                track: track
+            )
         )
     }
 
@@ -78,7 +78,7 @@ final class StreamSourceBuilder {
 
         videoTrack = StreamSource.VideoTrackInfo(
             mid: mid,
-            trackType: trackItem.trackType,
+            trackID: trackItem.trackID,
             mediaType: trackItem.mediaType,
             track: track
         )
@@ -110,7 +110,7 @@ final class StreamSourceBuilder {
             throw BuildError.missingAudioTrack
         }
 
-        guard !hasMissingVideoTrack else {
+        guard !hasMissingVideoTrack, let videoTrack = videoTrack else {
             throw BuildError.missingVideoTrack
         }
 

--- a/Sources/DolbyIORTSCore/Manager/SubscriptionManager.swift
+++ b/Sources/DolbyIORTSCore/Manager/SubscriptionManager.swift
@@ -164,19 +164,16 @@ final class SubscriptionManager: SubscriptionManagerProtocol {
 
     func addRemoteTrack(_ sourceBuilder: StreamSourceBuilder) {
         Self.logger.warning("💼 Add remote track for source - \(sourceBuilder.sourceId.value ?? "MAIN")")
-        sourceBuilder.supportedTrackItems.forEach { subscriber.addRemoteTrack($0.trackType.rawValue) }
+        sourceBuilder.supportedTrackItems.forEach { subscriber.addRemoteTrack($0.mediaType.rawValue) }
     }
 
     func projectVideo(for source: StreamSource, withQuality quality: StreamSource.VideoQuality) {
         Self.logger.debug("💼 Project video for source \(source.sourceId.value ?? "N/A")")
-        guard let videoTrack = source.videoTrack else {
-            return
-        }
-
+        let videoTrack = source.videoTrack
         let projectionData = MCProjectionData()
         projectionData.media = videoTrack.trackInfo.mediaType.rawValue
         projectionData.mid = videoTrack.trackInfo.mid
-        projectionData.trackId = videoTrack.trackInfo.trackType.rawValue
+        projectionData.trackId = videoTrack.trackInfo.trackID
         projectionData.layer = quality.layerData
 
         subscriber.project(source.sourceId.value, withData: [projectionData])
@@ -184,10 +181,7 @@ final class SubscriptionManager: SubscriptionManagerProtocol {
 
     func unprojectVideo(for source: StreamSource) {
         Self.logger.debug("💼 Project video for source \(source.sourceId.value ?? "N/A")")
-        guard let videoTrack = source.videoTrack else {
-            return
-        }
-
+        let videoTrack = source.videoTrack
         subscriber.unproject([videoTrack.trackInfo.mid])
     }
 
@@ -203,7 +197,7 @@ final class SubscriptionManager: SubscriptionManagerProtocol {
         audioTrack.track.setVolume(1)
         projectionData.media = audioTrack.trackInfo.mediaType.rawValue
         projectionData.mid = audioTrack.trackInfo.mid
-        projectionData.trackId = audioTrack.trackInfo.trackType.rawValue
+        projectionData.trackId = audioTrack.trackInfo.trackID
 
         subscriber.project(source.sourceId.value, withData: [projectionData])
     }
@@ -261,7 +255,7 @@ extension SubscriptionManager: MCSubscriberListener {
     }
 
     func onActive(_ streamId: String!, tracks: [String]!, sourceId: String!) {
-        Self.logger.debug("Callback -> onActive with sourceId \(sourceId ?? "NULL")")
+        Self.logger.debug("Callback -> onActive with sourceId \(sourceId ?? "NULL"), tracks - \(tracks)")
         delegate?.onActive(streamId, tracks: tracks, sourceId: sourceId)
     }
 

--- a/Sources/DolbyIORTSCore/Model/StreamSource.swift
+++ b/Sources/DolbyIORTSCore/Model/StreamSource.swift
@@ -30,17 +30,13 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
         }
     }
 
-    enum TrackType: String, Equatable {
-        case audio, video
-    }
-
     enum MediaType: String, Equatable {
         case audio, video
     }
 
     struct TrackInfo: Equatable, Hashable {
         public let mid: String
-        public let trackType: TrackType
+        public let trackID: String
         public let mediaType: MediaType
     }
 
@@ -49,8 +45,8 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
         public let track: MCAudioTrack
         public var trackId: String { track.getId() }
 
-        init(mid: String, trackType: TrackType, mediaType: MediaType, track: MCAudioTrack) {
-            self.trackInfo = TrackInfo(mid: mid, trackType: trackType, mediaType: mediaType)
+        init(mid: String, trackID: String, mediaType: MediaType, track: MCAudioTrack) {
+            self.trackInfo = TrackInfo(mid: mid, trackID: trackID, mediaType: mediaType)
             self.track = track
         }
     }
@@ -60,8 +56,8 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
         public let track: MCVideoTrack
         public var trackId: String { track.getId() }
 
-        init(mid: String, trackType: TrackType, mediaType: MediaType, track: MCVideoTrack) {
-            self.trackInfo = TrackInfo(mid: mid, trackType: trackType, mediaType: mediaType)
+        init(mid: String, trackID: String, mediaType: MediaType, track: MCVideoTrack) {
+            self.trackInfo = TrackInfo(mid: mid, trackID: trackID, mediaType: mediaType)
             self.track = track
         }
     }
@@ -122,7 +118,7 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
     let isPlayingAudio: Bool
     let isPlayingVideo: Bool
     let audioTracks: [AudioTrackInfo]
-    let videoTrack: VideoTrackInfo?
+    let videoTrack: VideoTrackInfo
 }
 
 extension StreamSource: Comparable {

--- a/Sources/DolbyIORTSCore/Model/StreamSourceViewRenderer.swift
+++ b/Sources/DolbyIORTSCore/Model/StreamSourceViewRenderer.swift
@@ -18,12 +18,10 @@ public class StreamSourceViewRenderer: Identifiable {
 
     public let id = UUID()
 
-    public init(_ source: StreamSource) {
-        guard let videoTrack = source.videoTrack?.track else {
-            fatalError("Cannot request renderer for a source that do not have video track")
-        }
+    public init(_ streamSource: StreamSource) {
+        let videoTrack = streamSource.videoTrack.track
         self.renderer = MCIosVideoRenderer()
-        self.source = source
+        self.source = streamSource
         self.videoTrack = videoTrack
 
         Task {

--- a/Sources/DolbyIORTSCore/StreamCoordinator.swift
+++ b/Sources/DolbyIORTSCore/StreamCoordinator.swift
@@ -141,11 +141,11 @@ open class StreamCoordinator {
         switch stateSubject.value {
         case let .subscribed(sources: sources, numberOfStreamViewers: _):
             guard
-                let matchingSource = sources.first(where: { $0.id == source.id }),
-                let videoTrack = source.videoTrack?.track
+                let matchingSource = sources.first(where: { $0.id == source.id })
             else {
                 return
             }
+            let videoTrack = source.videoTrack.track
             await rendererRegistry.registerRenderer(renderer, for: videoTrack)
 
             if !matchingSource.isPlayingVideo {
@@ -168,11 +168,11 @@ open class StreamCoordinator {
         case let .subscribed(sources: sources, numberOfStreamViewers: _):
             guard
                 let matchingSource = sources.first(where: { $0.id == source.id }),
-                matchingSource.isPlayingVideo,
-                let videoTrack = source.videoTrack?.track
+                matchingSource.isPlayingVideo
             else {
                 return
             }
+            let videoTrack = source.videoTrack.track
             await rendererRegistry.deregisterRenderer(renderer, for: videoTrack)
 
             let hasActiveRenderer = await rendererRegistry.hasActiveRenderer(for: videoTrack)


### PR DESCRIPTION
Description:

Tracks list passed as an argument on onActive call expects each item to be of format `{mediaType}/{trackID}` and these components are now decoded into plain string

Logs:

Tracks list from the onActive callback were previously of format `["audio/audio", "video/video"]` whereas now its converted to ["audio/audioCAM2", "video/videoCAM2"] - the client side code is now modified to accept plain string for these values