### PR TITLE
[Bugfix] Reconnect to the stream after lost connection

### DIFF
--- a/Sources/DolbyIORTSCore/State/StateMachine.swift
+++ b/Sources/DolbyIORTSCore/State/StateMachine.swift
@@ -82,7 +82,7 @@ final actor StateMachine {
 
     func onConnected() {
         switch currentState {
-        case .connecting:
+        case .connecting, .disconnected:
             currentState = .connected
         default:
             Self.logger.error("🛑 Unexpected state on onConnected - \(self.currentState.description)")

--- a/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -278,7 +278,7 @@ final class StreamViewModel: ObservableObject {
                     self.internalState = .loading
                 case let .error(streamError):
                     self.internalState = .error(ErrorViewModel(error: streamError))
-                case .stopped:
+                case .stopped, .disconnected:
                     self.internalState = .error(.streamOffline)
                 default:
                     // Handle's scenario where there is no sources


### PR DESCRIPTION
- Handling `.disconnected` state fixes the issue