### PR TITLE
Set VideoQuality for video sources

### DIFF
--- a/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
+++ b/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
@@ -4,8 +4,10 @@
 
 import Foundation
 import MillicastSDK
+import os
 
 final class StreamSourceBuilder {
+    private static let logger = Logger.make(category: String(describing: StreamSourceBuilder.self))
 
     enum BuildError: Error {
         case missingVideoTrack
@@ -38,11 +40,11 @@ final class StreamSourceBuilder {
     private(set) var supportedTrackItems: [TrackItem]
     private(set) var videoTrack: StreamSource.VideoTrackInfo?
     private(set) var audioTracks: [StreamSource.AudioTrackInfo] = []
-    private(set) var availableVideoQualityList: [StreamSource.VideoQuality] = [.auto]
-    private(set) var preferredVideoQuality: StreamSource.VideoQuality = .auto
+    private(set) var availableVideoQualityList: [StreamSource.LowLevelVideoQuality] = [.auto] 
     private(set) var isPlayingAudio = false
     private(set) var isPlayingVideo = false
     private(set) var streamingStatistics: StreamingStatistics? = nil
+    private(set) var selectedVideoQuality: StreamSource.LowLevelVideoQuality = .auto
 
     init(streamId: String, sourceId: String?, tracks: [String]) {
         identifier = UUID()
@@ -51,6 +53,7 @@ final class StreamSourceBuilder {
 
         supportedTrackItems = tracks
             .compactMap { TrackItem(track: $0) }
+        Self.logger.debug("🧱 Supported track items \(self.supportedTrackItems) for \(self.sourceId)")
     }
 
     func addAudioTrack(_ track: MCAudioTrack, mid: String) {
@@ -62,14 +65,14 @@ final class StreamSourceBuilder {
             return
         }
         let trackItem = trackItems[0]
-        audioTracks.append(
-            StreamSource.AudioTrackInfo(
-                mid: mid,
-                trackID: trackItem.trackID,
-                mediaType: trackItem.mediaType,
-                track: track
-            )
+        let audioTrack = StreamSource.AudioTrackInfo(
+            mid: mid,
+            trackID: trackItem.trackID,
+            mediaType: trackItem.mediaType,
+            track: track
         )
+        audioTracks.append(audioTrack)
+        Self.logger.debug("🧱 Add audio track for \(audioTrack) for \(self.sourceId)")
     }
 
     func addVideoTrack(_ track: MCVideoTrack, mid: String) {
@@ -77,33 +80,44 @@ final class StreamSourceBuilder {
             return
         }
 
-        videoTrack = StreamSource.VideoTrackInfo(
+        let videoTrack = StreamSource.VideoTrackInfo(
             mid: mid,
             trackID: trackItem.trackID,
             mediaType: trackItem.mediaType,
             track: track
         )
+        self.videoTrack = videoTrack
+        Self.logger.debug("🧱 Add video track for \(videoTrack) for \(self.sourceId)")
     }
 
-    func updatePreferredVideoQuality(_ videoQuality: StreamSource.VideoQuality) {
-        guard availableVideoQualityList.contains(where: { $0 == videoQuality }) else {
-            preferredVideoQuality = .auto
+    func setAvailableVideoQualityList(_ list: [StreamSource.LowLevelVideoQuality]) {
+        availableVideoQualityList = list
+        Self.logger.debug("🧱 Set available video quality list \(list) for \(self.sourceId)")
+        if let newVideoQuality = availableVideoQualityList.matching(videoQuality: VideoQuality(selectedVideoQuality)) {
+            selectedVideoQuality = newVideoQuality
+        } else {
+            selectedVideoQuality = .auto
+        }
+    }
+    
+    func setSelectedVideoQuality(_ videoQuality: VideoQuality) {
+        guard let videoQualityToSelect = availableVideoQualityList.matching(videoQuality: videoQuality) else {
+            selectedVideoQuality = .auto
             return
         }
 
-        preferredVideoQuality = videoQuality
-    }
-
-    func setAvailableVideoQualityList(_ list: [StreamSource.VideoQuality]) {
-        availableVideoQualityList = list
+        selectedVideoQuality = videoQualityToSelect
+        Self.logger.debug("🧱 Set selected video quality \(videoQualityToSelect) for \(self.sourceId)")
     }
 
     func setPlayingAudio(_ enable: Bool) {
         isPlayingAudio = enable
+        Self.logger.debug("🧱 Set audio playing state to \(enable) for \(self.sourceId)")
     }
     
     func setPlayingVideo(_ enable: Bool) {
         isPlayingVideo = enable
+        Self.logger.debug("🧱 Set video playing state to \(enable) for \(self.sourceId)")
     }
     
     func setStatistics(_ statistics: StreamingStatistics) {
@@ -123,23 +137,23 @@ final class StreamSourceBuilder {
             id: identifier,
             streamId: streamId,
             sourceId: sourceId,
-            availableVideoQualityList: availableVideoQualityList,
-            preferredVideoQuality: preferredVideoQuality,
-            streamingStatistics: streamingStatistics,
             isPlayingAudio: isPlayingAudio,
             isPlayingVideo: isPlayingVideo,
             audioTracks: audioTracks,
-            videoTrack: videoTrack
+            videoTrack: videoTrack,
+            lowLevelVideoQualityList: availableVideoQualityList,
+            selectedLowLevelVideoQuality: selectedVideoQuality,
+            streamingStatistics: streamingStatistics
         )
     }
 }
 
 // MARK: Helper functions
+
 // Note: Currently the Millicast SDK callbacks do not give us a way to associate the track we receive in onAudioTrack(..) and onVideoTrack(..) callbacks to a particular SourceId
 // The current implementation worked around it be checking for the missing `audio or video tracks` by comparing it with the `supportedTrackItems` - this SDK limitation leads
 // us in making assumptions that the mediaType will either be "audio" or "video".
 // TODO: Refactor this implementation when the SDK Callback API's are refined.
-
 extension StreamSourceBuilder {
     var hasMissingAudioTrack: Bool {
         let audioTrackItems = supportedTrackItems.filter { $0.mediaType == .audio }
@@ -149,5 +163,18 @@ extension StreamSourceBuilder {
     var hasMissingVideoTrack: Bool {
         let hasVideoTrack = supportedTrackItems.contains { $0.mediaType == .video }
         return hasVideoTrack && videoTrack == nil
+    }
+}
+
+extension Array where Self.Element == StreamSource.LowLevelVideoQuality {
+    func matching(videoQuality: VideoQuality) -> Self.Element? {
+        return self.first { internalVideoQuality in
+            switch (internalVideoQuality, videoQuality) {
+            case (.auto, .auto), (.high, .high), (.medium, .medium), (.low, .low):
+                return true
+            default:
+                return false
+            }
+        }
     }
 }

--- a/Sources/DolbyIORTSCore/Manager/RendererRegistry.swift
+++ b/Sources/DolbyIORTSCore/Manager/RendererRegistry.swift
@@ -7,66 +7,118 @@ import MillicastSDK
 import os
 
 protocol RendererRegistryProtocol: AnyObject {
-    func registerRenderer(_ renderer: StreamSourceViewRenderer, for track: MCVideoTrack) async
-    func deregisterRenderer(_ renderer: StreamSourceViewRenderer, for track: MCVideoTrack) async
+    func registerRenderer(_ renderer: StreamSourceViewRenderer, with quality: VideoQuality)
+    func deregisterRenderer(_ renderer: StreamSourceViewRenderer)
 
-    func hasActiveRenderer(for track: MCVideoTrack) async -> Bool
+    func hasActiveRenderer(for track: MCVideoTrack) -> Bool
+    func requestedVideoQuality(for track: MCVideoTrack) -> VideoQuality
 
-    func reset() async
+    func reset()
 }
 
-final actor RendererRegistry: RendererRegistryProtocol {
+final class RendererRegistry: RendererRegistryProtocol {
     private static let logger = Logger.make(category: String(describing: RendererRegistry.self))
 
-    private var rendererDictionary: [String: NSHashTable<StreamSourceViewRenderer>] = [:]
+    private typealias StreamRendererIdentifier = UUID
+    private typealias TrackIdentifier = String
+    private typealias ViewIdentifier = NSUUID
 
-    func registerRenderer(_ renderer: StreamSourceViewRenderer, for track: MCVideoTrack) {
-        guard let trackID = track.getId() else {
-            Self.logger.error("📺 Register renderer \(renderer.id) called with an invalid VideoTrack")
+    private var rendererDictionary: [TrackIdentifier: NSHashTable<StreamSourceViewRenderer>] = [:]
+    private var trackToVideoQualityDictionary: [TrackIdentifier: [StreamRendererIdentifier: VideoQuality]] = [:]
+
+    func registerRenderer(_ renderer: StreamSourceViewRenderer, with quality: VideoQuality) {
+        guard let trackID = renderer.videoTrack.getId() else {
+            Self.logger.warning("📺 Register renderer \(renderer.id) called with an invalid VideoTrack")
             return
         }
-
-        Self.logger.error("📺 Register renderer \(renderer.id)")
+        
+        // Update the requested video quality for a specific renderer
+        let rendererToQualityMapping: [StreamRendererIdentifier: VideoQuality]
+        if var existingRendererToQualityMapping = trackToVideoQualityDictionary[trackID] {
+            existingRendererToQualityMapping[renderer.id] = quality
+            rendererToQualityMapping = existingRendererToQualityMapping
+        } else {
+            rendererToQualityMapping = [renderer.id: quality]
+        }
+        trackToVideoQualityDictionary[trackID] = rendererToQualityMapping
+        
+        Self.logger.debug("📺 Register renderer \(renderer.id)")
         if let renderers = rendererDictionary[trackID] {
-            Self.logger.error("📺 Renderer dictionary has an entry for trackID - \(trackID)")
+            Self.logger.debug("📺 Renderer dictionary has an entry for trackID - \(trackID)")
             guard !renderers.contains(renderer) else {
-                Self.logger.error("📺 Renderer is already registered")
+                Self.logger.debug("📺 Renderer is already registered")
                 return
             }
             renderers.add(renderer)
         } else {
-            Self.logger.error("📺 Create a new renderer list for trackID - \(trackID)")
+            Self.logger.debug("📺 Create a new renderer list for trackID - \(trackID)")
             let renderers = NSHashTable<StreamSourceViewRenderer>(options: .weakMemory)
             renderers.add(renderer)
             rendererDictionary[trackID] = renderers
         }
     }
 
-    func deregisterRenderer(_ renderer: StreamSourceViewRenderer, for track: MCVideoTrack) {
-        guard let trackID = track.getId() else {
-            Self.logger.error("📺 Deregister renderer \(renderer.id) called with an invalid VideoTrack")
+    func deregisterRenderer(_ renderer: StreamSourceViewRenderer) {
+        guard let trackID = renderer.videoTrack.getId() else {
+            Self.logger.warning("📺 Deregister renderer \(renderer.id) called with an invalid VideoTrack")
             return
         }
 
-        Self.logger.error("📺 Deregister renderer \(renderer.id)")
+        Self.logger.debug("📺 Deregister renderer \(renderer.id)")
         if let renderers = rendererDictionary[trackID] {
             renderers.remove(renderer)
+        }
+        
+        if var rendererToQualityMapping = trackToVideoQualityDictionary[trackID] {
+            rendererToQualityMapping.removeValue(forKey: renderer.id)
+            trackToVideoQualityDictionary[trackID] = rendererToQualityMapping
         }
     }
 
     func hasActiveRenderer(for track: MCVideoTrack) -> Bool {
+        !activeRenderers(for: track).isEmpty
+    }
+    
+    func requestedVideoQuality(for track: MCVideoTrack) -> VideoQuality {
+        guard
+            let trackID = track.getId(),
+            let rendererToQualityMapping = trackToVideoQualityDictionary[trackID]
+        else {
+            return .auto
+        }
+        
+        let sortedVideoQualityList = rendererToQualityMapping.values
+            .sorted { $0.isGreaterThan(quality: $1) }
+        return sortedVideoQualityList.first ?? .auto
+    }
+    
+    private func activeRenderers(for track: MCVideoTrack) -> [StreamSourceViewRenderer] {
         guard
             let trackID = track.getId(),
             let renderers = rendererDictionary[trackID]
         else {
-            return false
+            return []
         }
 
-        return renderers.count != 0
+        return renderers.allObjects
     }
 
     func reset() {
-        Self.logger.error("📺 Reset renderer registry")
+        Self.logger.debug("📺 Reset renderer registry")
         rendererDictionary.removeAll()
+    }
+}
+
+fileprivate extension VideoQuality {
+    func isGreaterThan(quality: VideoQuality?) -> Bool {
+        switch (self, quality) {
+        case (.auto, .high), (.auto, .medium), (.auto, .low), (.auto, nil),
+            (.high, .medium), (.high, .low), (.high, nil),
+            (.medium, .low), (.medium, nil),
+            (.low, nil):
+            return true
+        default:
+            return false
+        }
     }
 }

--- a/Sources/DolbyIORTSCore/Model/StreamDetail.swift
+++ b/Sources/DolbyIORTSCore/Model/StreamDetail.swift
@@ -4,8 +4,14 @@
 
 import Foundation
 
-public struct StreamDetail: Equatable {
+public struct StreamDetail: Equatable, Identifiable {
+    public let id = UUID()
     public let streamName: String
     public let accountID: String
     public var streamId: String { "\(self.accountID)/\(self.streamName)" }
+    
+    public init(streamName: String, accountID: String) {
+        self.streamName = streamName
+        self.accountID = accountID
+    }
 }

--- a/Sources/DolbyIORTSCore/Model/StreamSource.swift
+++ b/Sources/DolbyIORTSCore/Model/StreamSource.swift
@@ -7,7 +7,7 @@ import MillicastSDK
 
 public struct StreamSource: Equatable, Hashable, Identifiable {
 
-    public enum SourceId: Equatable, Hashable {
+    public enum SourceId: Equatable, Hashable, CustomStringConvertible {
         case main
         case other(sourceId: String)
 
@@ -28,19 +28,31 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
                 return id
             }
         }
+        
+        public var description: String {
+            "SourceId: \(String(describing: value))"
+        }
     }
 
-    enum MediaType: String, Equatable {
+    enum MediaType: String, Equatable, CustomStringConvertible {
         case audio, video
+        
+        var description: String {
+            "MediaType: \(rawValue)"
+        }
     }
 
-    struct TrackInfo: Equatable, Hashable {
-        public let mid: String
-        public let trackID: String
-        public let mediaType: MediaType
+    struct TrackInfo: Equatable, Hashable, CustomStringConvertible {
+        let mid: String
+        let trackID: String
+        let mediaType: MediaType
+        
+        var description: String {
+            "TrackInfo: Mid - \(mid), trackID - \(trackID), media type - \(mediaType.rawValue)"
+        }
     }
 
-    struct AudioTrackInfo: Equatable, Hashable {
+    struct AudioTrackInfo: Equatable, Hashable, CustomStringConvertible {
         public let trackInfo: TrackInfo
         public let track: MCAudioTrack
         public var trackId: String { track.getId() }
@@ -49,9 +61,13 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
             self.trackInfo = TrackInfo(mid: mid, trackID: trackID, mediaType: mediaType)
             self.track = track
         }
+        
+        public var description: String {
+            "AudioTrackInfo: Remote Track Identifier - \(trackId), track info - \(trackInfo)"
+        }
     }
 
-    struct VideoTrackInfo: Equatable, Hashable {
+    struct VideoTrackInfo: Equatable, Hashable, CustomStringConvertible {
         public let trackInfo: TrackInfo
         public let track: MCVideoTrack
         public var trackId: String { track.getId() }
@@ -60,9 +76,13 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
             self.trackInfo = TrackInfo(mid: mid, trackID: trackID, mediaType: mediaType)
             self.track = track
         }
+        
+        public var description: String {
+            "VideoTrackInfo: Remote Track Identifier - \(trackId), track info - \(trackInfo)"
+        }
     }
-
-    public enum VideoQuality: Equatable, Hashable, CustomStringConvertible {
+    
+    enum LowLevelVideoQuality: Equatable, Hashable, CustomStringConvertible {
         case auto
         case high(layer: MCLayerData)
         case medium(layer: MCLayerData)
@@ -113,13 +133,21 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
     public let id: UUID
     public let streamId: String
     public let sourceId: SourceId
-    public let availableVideoQualityList: [VideoQuality]
-    public let preferredVideoQuality: VideoQuality
-    public let streamingStatistics: StreamingStatistics?
     let isPlayingAudio: Bool
     let isPlayingVideo: Bool
     let audioTracks: [AudioTrackInfo]
     let videoTrack: VideoTrackInfo
+    let lowLevelVideoQualityList: [LowLevelVideoQuality]
+    let selectedLowLevelVideoQuality: LowLevelVideoQuality
+    public let streamingStatistics: StreamingStatistics?
+
+    public var videoQualityList: [VideoQuality] {
+        lowLevelVideoQualityList.map(VideoQuality.init)
+    }
+    
+    public var selectedVideoQuality: VideoQuality {
+        VideoQuality(selectedLowLevelVideoQuality)
+    }
 }
 
 extension StreamSource: Comparable {

--- a/Sources/DolbyIORTSCore/Model/StreamSourceViewRenderer.swift
+++ b/Sources/DolbyIORTSCore/Model/StreamSourceViewRenderer.swift
@@ -13,15 +13,14 @@ public class StreamSourceViewRenderer: Identifiable {
     }
 
     private let renderer: MCIosVideoRenderer
-    private let source: StreamSource
-    private var videoTrack: MCVideoTrack
+    
+    let videoTrack: MCVideoTrack
 
     public let id = UUID()
 
     public init(_ streamSource: StreamSource) {
         let videoTrack = streamSource.videoTrack.track
         self.renderer = MCIosVideoRenderer()
-        self.source = streamSource
         self.videoTrack = videoTrack
 
         Task {
@@ -29,10 +28,6 @@ public class StreamSourceViewRenderer: Identifiable {
                 videoTrack.add(renderer)
             }
         }
-    }
-
-    private var hasValidDimensions: Bool {
-        renderer.getWidth() != 0 && renderer.getHeight() != 0
     }
 
     public var frameWidth: CGFloat {
@@ -45,5 +40,14 @@ public class StreamSourceViewRenderer: Identifiable {
 
     public var playbackView: UIView {
         renderer.getView()
+    }
+}
+
+// MARK: Helper functions
+
+extension StreamSourceViewRenderer {
+    
+    private var hasValidDimensions: Bool {
+        renderer.getWidth() != 0 && renderer.getHeight() != 0
     }
 }

--- a/Sources/DolbyIORTSCore/Model/VideoQuality.swift
+++ b/Sources/DolbyIORTSCore/Model/VideoQuality.swift
@@ -1,0 +1,38 @@
+//
+//  VideoQuality.swift
+//
+
+import Foundation
+
+public enum VideoQuality: Equatable {
+    case auto
+    case high
+    case medium
+    case low
+    
+    init(_ viewQualityInternal: StreamSource.LowLevelVideoQuality) {
+        switch viewQualityInternal {
+        case .auto:
+            self = .auto
+        case .high:
+            self = .high
+        case .medium:
+            self = .medium
+        case .low:
+            self = .low
+        }
+    }
+    
+    public var description: String {
+        switch self {
+        case .auto:
+            return "Auto"
+        case .high:
+            return "High"
+        case .medium:
+            return "Medium"
+        case .low:
+            return "Low"
+        }
+    }
+}

--- a/Sources/DolbyIORTSCore/State/State.swift
+++ b/Sources/DolbyIORTSCore/State/State.swift
@@ -77,13 +77,6 @@ struct SubscribedState {
         streamSourceBuilders.remove(at: indexToRemove)
     }
 
-    func updatePreferredVideoQuality(_ videoQuality: StreamSource.VideoQuality, for sourceId: String?) {
-        guard let builder = streamSourceBuilders.first(where: { $0.sourceId.value == sourceId }) else {
-            return
-        }
-        builder.updatePreferredVideoQuality(videoQuality)
-    }
-
     func setPlayingAudio(_ enable: Bool, for sourceId: String?) {
         guard let builder = streamSourceBuilders.first(where: { $0.sourceId.value == sourceId }) else {
             return
@@ -98,12 +91,19 @@ struct SubscribedState {
         builder.setPlayingVideo(enable)
     }
 
-    func setAvailableStreamTypes(_ list: [StreamSource.VideoQuality], for mid: String) {
+    func setAvailableStreamTypes(_ list: [StreamSource.LowLevelVideoQuality], for mid: String) {
         guard let builder = streamSourceBuilders.first(where: { $0.videoTrack?.trackInfo.mid == mid }) else {
             return
         }
 
         builder.setAvailableVideoQualityList(list)
+    }
+    
+    func setSelectedVideoQuality(_ videoQuality: VideoQuality, for sourceId: String?) {
+        guard let builder = streamSourceBuilders.first(where: { $0.sourceId.value == sourceId }) else {
+            return
+        }
+        builder.setSelectedVideoQuality(videoQuality)
     }
 
     mutating func updateViewerCount(_ count: Int) {

--- a/Sources/DolbyIORTSCore/StreamOrchestrator.swift
+++ b/Sources/DolbyIORTSCore/StreamOrchestrator.swift
@@ -7,7 +7,8 @@ import Foundation
 import MillicastSDK
 import os
 
-open class StreamOrchestrator {
+@globalActor
+public final actor StreamOrchestrator {
     public struct Configuration {
         let retryOnConnectionError = true
     }
@@ -30,13 +31,10 @@ open class StreamOrchestrator {
     public lazy var statePublisher: AnyPublisher<StreamState, Never> = stateSubject
         .removeDuplicates()
         .eraseToAnyPublisher()
-    public private(set) var activeStreamDetail: StreamDetail?
-
-    private typealias OrchestratorTask = Task<Void, Never>
-    private var taskStreamContinuation: AsyncStream<OrchestratorTask>.Continuation?
+    private var activeStreamDetail: StreamDetail?
     private static var configuration: StreamOrchestrator.Configuration = .init()
     
-    private convenience init() {
+    private init() {
         self.init(
             subscriptionManager: SubscriptionManager(),
             taskScheduler: TaskScheduler(),
@@ -59,13 +57,16 @@ open class StreamOrchestrator {
 
         self.subscriptionManager.delegate = self
 
-        startStateObservation()
-        startStateMachineTasksSerialExecutor()
         Utils.configureAudioSession()
+
+        Task { [weak self] in
+            guard let self = self else { return }
+            await self.startStateObservation()
+        }
     }
 
     public func connect(streamName: String, accountID: String) async -> Bool {
-        Self.logger.error("👮‍♂️ Start subscribe")
+        Self.logger.debug("👮‍♂️ Start subscribe")
 
         async let startConnectionStateUpdate: Void = stateMachine.startConnection(streamName: streamName, accountID: accountID)
         async let startConnection = subscriptionManager.connect(streamName: streamName, accountID: accountID)
@@ -78,7 +79,7 @@ open class StreamOrchestrator {
     }
 
     public func stopConnection() async -> Bool {
-        Self.logger.error("👮‍♂️ Stop subscribe")
+        Self.logger.debug("👮‍♂️ Stop subscribe")
         activeStreamDetail = nil
         async let stopSubscribeOnStateMachine: Void = stateMachine.stopSubscribe()
         async let resetRegistry: Void = rendererRegistry.reset()
@@ -87,83 +88,71 @@ open class StreamOrchestrator {
         return stopSubscribeResult
     }
 
-    public func selectVideoQuality(_ quality: StreamSource.VideoQuality, for source: StreamSource) {
-        Self.logger.error("👮‍♂️ Select video quality \(quality.description) for source - \(source.sourceId.value ?? "Main")")
-        subscriptionManager.selectVideoQuality(quality, for: source)
-    }
-
     public func playAudio(for source: StreamSource) async {
-        Self.logger.error("👮‍♂️ Play Audio for source - \(source.sourceId.value ?? "Main")")
-        switch stateSubject.value {
-        case let .subscribed(sources: sources, numberOfStreamViewers: _):
+        Self.logger.debug("👮‍♂️ Play Audio for source - \(String(describing: source.sourceId.value))")
+        switch stateMachine.currentState {
+        case let .subscribed(subscribedState):
             guard
-                let matchingSource = sources.first(where: { $0.id == source.id }),
+                let matchingSource = subscribedState.sources.first(where: { $0.id == source.id }),
                 !matchingSource.isPlayingAudio
             else {
                 return
             }
-            await withTaskGroup(of: Void.self) { [weak self] group in
-                guard let self = self else { return }
-
-                for source in sources {
-                    guard source.isPlayingAudio else {
-                        continue
-                    }
-                    
-                    group.addTask {
-                        await self.stateMachine.setPlayingAudio(false, for: source)
-                        self.subscriptionManager.unprojectAudio(for: source)
-                    }
+            for source in subscribedState.sources {
+                guard source.isPlayingAudio else {
+                    continue
                 }
                 
-                group.addTask {
-                    self.subscriptionManager.projectAudio(for: source)
-                    await self.stateMachine.setPlayingAudio(true, for: source)
-                }
+                stateMachine.setPlayingAudio(false, for: source)
+                subscriptionManager.unprojectAudio(for: source)
             }
+            
+            subscriptionManager.projectAudio(for: source)
+            stateMachine.setPlayingAudio(true, for: source)
         default:
             return
         }
     }
 
     public func stopAudio(for source: StreamSource) async {
-        Self.logger.error("👮‍♂️ Stop Audio for source - \(source.sourceId.value ?? "Main")")
+        Self.logger.debug("👮‍♂️ Stop Audio for source - \(String(describing: source.sourceId.value))")
 
-        switch stateSubject.value {
-        case let .subscribed(sources: sources, numberOfStreamViewers: _):
+        switch stateMachine.currentState {
+        case let .subscribed(subscribedState):
             guard
-                let matchingSource = sources.first(where: { $0.id == source.id }),
+                let matchingSource = subscribedState.sources.first(where: { $0.id == source.id }),
                 matchingSource.isPlayingAudio
             else {
                 return
             }
-            subscriptionManager.unprojectAudio(for: source)
-            await stateMachine.setPlayingAudio(false, for: source)
+            subscriptionManager.unprojectAudio(for: matchingSource)
+            stateMachine.setPlayingAudio(false, for: matchingSource)
 
         default:
             return
         }
     }
 
-    public func playVideo(for source: StreamSource, on renderer: StreamSourceViewRenderer, quality: StreamSource.VideoQuality) async {
-        Self.logger.error("👮‍♂️ Play Video for source - \(source.sourceId.value ?? "Main") on renderer - \(renderer.id)")
+    public func playVideo(for source: StreamSource, on renderer: StreamSourceViewRenderer, with quality: VideoQuality) async {
+        Self.logger.debug("👮‍♂️ Play Video for source - \(String(describing: source.sourceId.value)) on renderer - \(renderer.id) with quality - \(quality.description)")
 
-        switch stateSubject.value {
-        case let .subscribed(sources: sources, numberOfStreamViewers: _):
+        switch stateMachine.currentState {
+        case let .subscribed(subscribedState):
             guard
-                let matchingSource = sources.first(where: { $0.id == source.id })
+                let matchingSource = subscribedState.sources.first(where: { $0.id == source.id })
             else {
                 return
             }
-            let videoTrack = source.videoTrack.track
-            await rendererRegistry.registerRenderer(renderer, for: videoTrack)
-
-            if !matchingSource.isPlayingVideo {
-                subscriptionManager.projectVideo(for: source, withQuality: quality)
-                _ = await (
-                    stateMachine.setPlayingVideo(true, for: source),
-                    stateMachine.selectVideoQuality(quality, for: source)
-                )
+            let videoTrack = matchingSource.videoTrack.track
+            rendererRegistry.registerRenderer(renderer, with: quality)
+            let requestedVideoQuality = rendererRegistry.requestedVideoQuality(for: videoTrack)
+            let videoQualityToRender = matchingSource.videoQualityList.contains(requestedVideoQuality) ?
+                requestedVideoQuality : .auto
+            
+            if !matchingSource.isPlayingVideo || matchingSource.selectedVideoQuality != videoQualityToRender {
+                subscriptionManager.projectVideo(for: matchingSource, withQuality: videoQualityToRender)
+                stateMachine.setPlayingVideo(true, for: matchingSource)
+                stateMachine.selectVideoQuality(videoQualityToRender, for: matchingSource)
             }
 
         default:
@@ -172,24 +161,40 @@ open class StreamOrchestrator {
     }
 
     public func stopVideo(for source: StreamSource, on renderer: StreamSourceViewRenderer) async {
-        Self.logger.error("👮‍♂️ Stop Video for source - \(source.sourceId.value ?? "Main") on renderer - \(renderer.id)")
+        Self.logger.debug("👮‍♂️ Stop Video for source - \(String(describing: source.sourceId.value)) on renderer - \(renderer.id)")
 
-        switch stateSubject.value {
-        case let .subscribed(sources: sources, numberOfStreamViewers: _):
+        switch stateMachine.currentState {
+        case let .subscribed(subscribedState):
             guard
-                let matchingSource = sources.first(where: { $0.id == source.id }),
+                let matchingSource = subscribedState.sources.first(where: { $0.id == source.id }),
                 matchingSource.isPlayingVideo
             else {
                 return
             }
-            let videoTrack = source.videoTrack.track
-            await rendererRegistry.deregisterRenderer(renderer, for: videoTrack)
+            let videoTrack = matchingSource.videoTrack.track
+            rendererRegistry.deregisterRenderer(renderer)
 
-            let hasActiveRenderer = await rendererRegistry.hasActiveRenderer(for: videoTrack)
+            let hasActiveRenderer = rendererRegistry.hasActiveRenderer(for: videoTrack)
             if !hasActiveRenderer {
                 subscriptionManager.unprojectVideo(for: source)
-                await stateMachine.setPlayingVideo(false, for: source)
+                stateMachine.setPlayingVideo(false, for: matchingSource)
+                stateMachine.onLayers(
+                    matchingSource.videoTrack.trackInfo.mid,
+                    activeLayers: [],
+                    inactiveLayers: []
+                )
+            } else {
+                let requestedVideoQuality = rendererRegistry.requestedVideoQuality(for: videoTrack)
+                let videoQualityToRender = matchingSource.videoQualityList.contains(requestedVideoQuality) ?
+                    requestedVideoQuality : .auto
+                
+                if matchingSource.selectedVideoQuality != videoQualityToRender {
+                    subscriptionManager.projectVideo(for: matchingSource, withQuality: videoQualityToRender)
+                    stateMachine.setPlayingVideo(true, for: matchingSource)
+                    stateMachine.selectVideoQuality(videoQualityToRender, for: matchingSource)
+                }
             }
+            
         default:
             return
         }
@@ -200,40 +205,41 @@ open class StreamOrchestrator {
 
 private extension StreamOrchestrator {
     func startStateObservation() {
-        Task { [weak self] in
-            guard let self = self else { return }
-            await self.stateMachine.statePublisher
-                .sink { state in
+        stateMachine.statePublisher
+            .sink { state in
+                Task { [weak self] in
+                    guard let self = self else { return }
                     switch state {
                     case let .error(errorState):
                         switch errorState.error {
                         case .connectFailed:
-                            self.scheduleReconnection()
+                            await self.scheduleReconnection()
                         default:
                             //No-op
                             break
                         }
                     case .stopped:
-                        self.scheduleReconnection()
+                        await self.scheduleReconnection()
+                        
                     default:
                         // No-op
                         break
                     }
-
+                    
                     // Populate updates public facing states
-                    self.stateSubject.send(StreamState(state: state))
+                    await self.stateSubject.send(StreamState(state: state))
                 }
+            }
             .store(in: &subscriptions)
-        }
     }
     
     func scheduleReconnection() {
-        guard Self.configuration.retryOnConnectionError else {
+        guard Self.configuration.retryOnConnectionError, let streamDetail = self.activeStreamDetail else {
             return
         }
-        Self.logger.error("👮‍♂️ Scheduling a reconnect")
+        Self.logger.debug("👮‍♂️ Scheduling a reconnect")
         taskScheduler.scheduleTask(timeInterval: Defaults.retryConnectionTimeInterval) { [weak self] in
-            guard let self = self, let streamDetail = self.activeStreamDetail else { return }
+            guard let self = self else { return }
             Task {
                 self.taskScheduler.invalidate()
                 _ = await self.connect(
@@ -243,34 +249,16 @@ private extension StreamOrchestrator {
             }
         }
     }
-    
-    func startStateMachineTasksSerialExecutor() {
-        Self.logger.error("👮‍♂️ Start serial task executor")
-        Task { [weak self] in
-            guard let self = self else { return }
-            
-            let taskStream = AsyncStream<OrchestratorTask> { continuation in
-                self.taskStreamContinuation = continuation
-            }
-            
-            for await task in taskStream {
-                await task.value
-            }
-        }
-    }
 
     func startSubscribe() async -> Bool {
-        async let startSubscribeStateUpdate: Void = stateMachine.startSubscribe()
-        async let startSubscribe = subscriptionManager.startSubscribe()
-        let (_, success) = await (startSubscribeStateUpdate, startSubscribe)
-        return success
+        stateMachine.startSubscribe()
+        return await subscriptionManager.startSubscribe()
     }
     
-    func stopAudio(for sourceId: String) async {
-        switch await stateMachine.currentState {
-        case let .subscribed(state):
-            if let source = state.sources.first (where: { $0.sourceId.value == sourceId }),
-               source.isPlayingAudio == true {
+    func stopAudio(for sourceId: String) {
+        switch stateSubject.value {
+        case let .subscribed(sources: sources, numberOfStreamViewers: _):
+            if let source = sources.first (where: { $0.sourceId.value == sourceId }), source.isPlayingAudio {
                 subscriptionManager.unprojectAudio(for: source)
             }
         default: break
@@ -282,111 +270,99 @@ private extension StreamOrchestrator {
 
 extension StreamOrchestrator: SubscriptionManagerDelegate {
     
-    public func onDisconnected() {
-        let task = Task { [weak self] in
+    nonisolated func onDisconnected() {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onDisconnected()
+            self.stateMachine.onDisconnected()
         }
-        taskStreamContinuation?.yield(task)
     }
     
-    public func onSubscribedError(_ reason: String) {
-        let task = Task { [weak self] in
+    nonisolated func onSubscribedError(_ reason: String) {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onSubscribedError(reason)
+            self.stateMachine.onSubscribedError(reason)
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onSignalingError(_ message: String) {
-        let task = Task { [weak self] in
+    nonisolated func onSignalingError(_ message: String) {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onSignalingError(message)
+            self.stateMachine.onSignalingError(message)
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onConnectionError(_ status: Int32, withReason reason: String) {
-        let task = Task { [weak self] in
+    nonisolated func onConnectionError(_ status: Int32, withReason reason: String) {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onConnectionError(status, withReason: reason)
+            self.stateMachine.onConnectionError(status, withReason: reason)
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onStopped() {
-        let task = Task { [weak self] in
+    nonisolated func onStopped() {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onStopped()
+            self.stateMachine.onStopped()
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onConnected() {
-        let task = Task { [weak self] in
+    nonisolated func onConnected() {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onConnected()
+            self.stateMachine.onConnected()
             _ = await self.startSubscribe()
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onSubscribed() {
-        let task = Task { [weak self] in
+    nonisolated func onSubscribed() {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onSubscribed()
+            self.stateMachine.onSubscribed()
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onVideoTrack(_ track: MCVideoTrack, withMid mid: String) {
-        let task = Task { [weak self] in
+    nonisolated func onVideoTrack(_ track: MCVideoTrack, withMid mid: String) {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onVideoTrack(track, withMid: mid)
+            self.stateMachine.onVideoTrack(track, withMid: mid)
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onAudioTrack(_ track: MCAudioTrack, withMid mid: String) {
-        let task = Task { [weak self] in
+    nonisolated func onAudioTrack(_ track: MCAudioTrack, withMid mid: String) {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onAudioTrack(track, withMid: mid)
+            self.stateMachine.onAudioTrack(track, withMid: mid)
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onStatsReport(_ report: MCStatsReport) {
+    nonisolated public func onStatsReport(_ report: MCStatsReport) {
         guard let streamingStats = AllStreamingStatistics(report) else {
             return
         }
-        let task = Task { [weak self] in
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onStatsReport(streamingStats)
+            self.stateMachine.onStatsReport(streamingStats)
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onViewerCount(_ count: Int32) {
-        let task = Task { [weak self] in
+    nonisolated func onViewerCount(_ count: Int32) {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.updateNumberOfStreamViewers(count)
+            self.stateMachine.updateNumberOfStreamViewers(count)
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onLayers(_ mid_: String, activeLayers: [MCLayerData], inactiveLayers: [MCLayerData]) {
-        let task = Task { [weak self] in
+    nonisolated func onLayers(_ mid_: String, activeLayers: [MCLayerData], inactiveLayers: [MCLayerData]) {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onLayers(mid_, activeLayers: activeLayers, inactiveLayers: inactiveLayers)
+            self.stateMachine.onLayers(mid_, activeLayers: activeLayers, inactiveLayers: inactiveLayers)
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onActive(_ streamId: String, tracks: [String], sourceId: String?) {
-        let task = Task { [weak self] in
+    nonisolated func onActive(_ streamId: String, tracks: [String], sourceId: String?) {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
-            await self.stateMachine.onActive(streamId, tracks: tracks, sourceId: sourceId)
-            let stateMachineState = await self.stateMachine.currentState
+            self.stateMachine.onActive(streamId, tracks: tracks, sourceId: sourceId)
+            let stateMachineState = self.stateMachine.currentState
             switch stateMachineState {
             case let .subscribed(state):
                 guard let sourceBuilder = state.streamSourceBuilders.first(where: { $0.sourceId.value == sourceId }) else {
@@ -397,11 +373,10 @@ extension StreamOrchestrator: SubscriptionManagerDelegate {
                 return
             }
         }
-        taskStreamContinuation?.yield(task)
     }
 
-    public func onInactive(_ streamId: String, sourceId: String?) {
-        let task = Task { [weak self] in
+    nonisolated func onInactive(_ streamId: String, sourceId: String?) {
+        Task { @StreamOrchestrator [weak self] in
             guard let self = self else { return }
             
             // Unproject audio whose source is inactive
@@ -409,8 +384,7 @@ extension StreamOrchestrator: SubscriptionManagerDelegate {
                 await self.stopAudio(for: sourceId)
             }
             
-            await self.stateMachine.onInactive(streamId, sourceId: sourceId)
+            self.stateMachine.onInactive(streamId, sourceId: sourceId)
         }
-        taskStreamContinuation?.yield(task)
     }
 }

--- a/Sources/DolbyIORTSUIKit/Private/Models/StreamSourceAndViewRenderers.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Models/StreamSourceAndViewRenderers.swift
@@ -5,26 +5,15 @@
 import DolbyIORTSCore
 import Foundation
 
-final class StreamSourceAndViewRenderers {
-    private var primaryRendererDictionary: [UUID: StreamSourceViewRenderer] = [:]
-    private var secondaryRendererDictionary: [UUID: StreamSourceViewRenderer] = [:]
+final class ViewRendererProvider: ObservableObject {
+    private var rendererDictionary: [UUID: StreamSourceViewRenderer] = [:]
 
-    func primaryRenderer(for source: StreamSource) -> StreamSourceViewRenderer {
-        if let renderer = primaryRendererDictionary[source.id] {
+    func renderer(for source: StreamSource) -> StreamSourceViewRenderer {
+        if let renderer = rendererDictionary[source.id] {
             return renderer
         } else {
             let renderer = StreamSourceViewRenderer(source)
-            primaryRendererDictionary[source.id] = renderer
-            return renderer
-        }
-    }
-
-    func secondaryRenderer(for source: StreamSource) -> StreamSourceViewRenderer {
-        if let renderer = secondaryRendererDictionary[source.id] {
-            return renderer
-        } else {
-            let renderer = StreamSourceViewRenderer(source)
-            secondaryRendererDictionary[source.id] = renderer
+            rendererDictionary[source.id] = renderer
             return renderer
         }
     }

--- a/Sources/DolbyIORTSUIKit/Private/Views/GridView/GridView.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Views/GridView/GridView.swift
@@ -31,6 +31,7 @@ struct GridView: View {
     private let layout: GridViewLayout
     private let onVideoSelection: (StreamSource) -> Void
     @State private var deviceOrientation: UIDeviceOrientation = UIDeviceOrientation.portrait
+    @StateObject private var viewRendererProvider: ViewRendererProvider = .init()
 
     init(
         viewModel: GridViewModel,
@@ -72,12 +73,14 @@ struct GridView: View {
                     
                     VideoRendererView(
                         viewModel: viewModel,
+                        viewRenderer: viewRendererProvider.renderer(for: viewModel.streamSource),
                         maxWidth: maxAllowedSubVideoWidth,
                         maxHeight: maxAllowedSubVideoHeight,
                         contentMode: .aspectFit
                     ) { source in
                         onVideoSelection(source)
                     }
+                    .id(viewModel.streamSource.id)
                     .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .center)
                 }
             }
@@ -93,12 +96,14 @@ struct GridView: View {
                 ForEach(viewModel.allVideoViewModels, id: \.streamSource.id) { viewModel in
                     VideoRendererView(
                         viewModel: viewModel,
+                        viewRenderer: viewRendererProvider.renderer(for: viewModel.streamSource),
                         maxWidth: .infinity,
                         maxHeight: availableHeight / CGFloat(rowsCount),
                         contentMode: .aspectFit
                     ) { source in
                         onVideoSelection(source)
                     }
+                    .id(viewModel.streamSource.id)
                 }
             }.frame(height: availableHeight)
         }

--- a/Sources/DolbyIORTSUIKit/Private/Views/LiveIndicator/LiveIndicatorViewModel.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Views/LiveIndicator/LiveIndicatorViewModel.swift
@@ -18,17 +18,20 @@ final class LiveIndicatorViewModel: ObservableObject {
     }
 
     private func setupStateObservers() {
-        streamOrchestrator.statePublisher
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] state in
-                guard let self = self else { return }
-                switch state {
-                case let .subscribed(sources: sources, numberOfStreamViewers: _):
-                    self.isStreamActive = !sources.isEmpty
-                default:
-                    break
+        Task { [weak self] in
+            guard let self = self else { return }
+
+            await self.streamOrchestrator.statePublisher
+                .receive(on: DispatchQueue.main)
+                .sink { state in
+                    switch state {
+                    case let .subscribed(sources: sources, numberOfStreamViewers: _):
+                        self.isStreamActive = !sources.isEmpty
+                    default:
+                        break
+                    }
                 }
-            }
-            .store(in: &subscriptions)
+                .store(in: &subscriptions)
+        }
     }
 }

--- a/Sources/DolbyIORTSUIKit/Private/Views/SingleStream/SingleStreamView.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Views/SingleStream/SingleStreamView.swift
@@ -24,6 +24,7 @@ struct SingleStreamView: View {
     @State private var isShowingSettingsScreen: Bool = false
     @State private var isShowingStatsInfoScreen: Bool = false
     @StateObject private var userInteractionViewModel: UserInteractionViewModel = .init()
+    @StateObject private var viewRendererProvider: ViewRendererProvider = .init()
 
     @ObservedObject private var themeManager = ThemeManager.shared
 
@@ -97,16 +98,13 @@ struct SingleStreamView: View {
                     ForEach(viewModel.videoViewModels, id: \.streamSource.id) { videoRendererViewModel in
                         let maxAllowedVideoWidth = proxy.size.width
                         let maxAllowedVideoHeight = proxy.size.height
-                        ZStack {
-                            HStack {
-                                VideoRendererView(
-                                    viewModel: videoRendererViewModel,
-                                    maxWidth: maxAllowedVideoWidth,
-                                    maxHeight: maxAllowedVideoHeight,
-                                    contentMode: .aspectFit
-                                )
-                            }
-                        }
+                        VideoRendererView(
+                            viewModel: videoRendererViewModel,
+                            viewRenderer: viewRendererProvider.renderer(for: videoRendererViewModel.streamSource),
+                            maxWidth: maxAllowedVideoWidth,
+                            maxHeight: maxAllowedVideoHeight,
+                            contentMode: .aspectFit
+                        )
                         .sheet(isPresented: $isShowingStatsInfoScreen) {
                             statisticsView()
                         }

--- a/Sources/DolbyIORTSUIKit/Private/Views/VideoRenderer/VideoRendererViewModel.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Views/VideoRenderer/VideoRendererViewModel.swift
@@ -9,43 +9,50 @@ enum VideoRendererContentMode {
     case aspectFit, aspectFill, scaleToFill
 }
 
-final class VideoRendererViewModel {
+final class VideoRendererViewModel: ObservableObject {
 
     private let streamOrchestrator: StreamOrchestrator
     let isSelectedVideoSource: Bool
     let isSelectedAudioSource: Bool
     let streamSource: StreamSource
-    let viewRenderer: StreamSourceViewRenderer
     let showSourceLabel: Bool
     let showAudioIndicator: Bool
+    @Published var videoQuality: VideoQuality
 
     init(
         streamSource: StreamSource,
-        viewRenderer: StreamSourceViewRenderer,
         isSelectedVideoSource: Bool,
         isSelectedAudioSource: Bool,
         showSourceLabel: Bool,
         showAudioIndicator: Bool,
+        videoQuality: VideoQuality,
         streamOrchestrator: StreamOrchestrator = .shared
     ) {
         self.streamSource = streamSource
-        self.viewRenderer = viewRenderer
         self.isSelectedVideoSource = isSelectedVideoSource
         self.isSelectedAudioSource = isSelectedAudioSource
         self.showSourceLabel = showSourceLabel
         self.showAudioIndicator = showAudioIndicator
+        self.videoQuality = videoQuality
         self.streamOrchestrator = streamOrchestrator
     }
-
-    func playVideo(for source: StreamSource) {
-        Task {
-            await self.streamOrchestrator.playVideo(for: source, on: viewRenderer, quality: .auto)
+    
+    func playVideo(on viewRenderer: StreamSourceViewRenderer, quality: VideoQuality? = nil) {
+        Task { @StreamOrchestrator in
+            await self.streamOrchestrator.playVideo(
+                for: streamSource,
+                on: viewRenderer,
+                with: quality ?? videoQuality
+            )
         }
     }
 
-    func stopVideo(for source: StreamSource) {
-        Task {
-            await self.streamOrchestrator.stopVideo(for: source, on: viewRenderer)
+    func stopVideo(on viewRenderer: StreamSourceViewRenderer) {
+        Task { @StreamOrchestrator in
+            await self.streamOrchestrator.stopVideo(
+                for: streamSource,
+                on: viewRenderer
+            )
         }
     }
 }

--- a/Sources/DolbyIORTSUIKit/Public/Screens/Media/StreamingScreen.swift
+++ b/Sources/DolbyIORTSUIKit/Public/Screens/Media/StreamingScreen.swift
@@ -7,16 +7,18 @@ import DolbyIORTSCore
 import DolbyIOUIKit
 
 public struct StreamingScreen: View {
-    @StateObject private var viewModel: StreamViewModel = .init()
-    @Binding private var isShowingStreamView: Bool
+    @StateObject private var viewModel: StreamViewModel
     @State private var isShowingSingleViewScreen: Bool = false
     @State private var isShowingSettingsScreen: Bool = false
     @ObservedObject private var themeManager = ThemeManager.shared
     
+    private let onClose: () -> Void
+    
     private var theme: Theme { themeManager.theme }
     
-    public init(isShowingStreamView: Binding<Bool>) {
-        _isShowingStreamView = isShowingStreamView
+    public init(streamDetail: StreamDetail, onClose: @escaping () -> Void) {
+        _viewModel = StateObject(wrappedValue: .init(streamDetail: streamDetail))
+        self.onClose = onClose
     }
 
     @ViewBuilder
@@ -180,7 +182,7 @@ public struct StreamingScreen: View {
 
 extension StreamingScreen {
     func endStream() {
-        _isShowingStreamView.wrappedValue = false
+        onClose()
         Task {
             await viewModel.endStream()
         }


### PR DESCRIPTION
Set primary tile for the ListView and GridView and all the SingleView video view's to use `auto` for video quality All thumbnail tiles including all the grid view's are set to `low` video quality, Optimise video quality selection in Core framework.

Description:
1. As part of this implementation StreamOrchestrator is made a global actor, this is to serialise method calls to Orchestrator. 
As an example, two tasks `PlayVideo` and `StopVideo` scheduled via `Task` blocks has to execute in the same order as they are scheduled, because a change in order can lead to unexpected UI behaviour such as paused or frozen video tile.
2. StreamDetail is passed into the StreamingScreen via its initialiser. The reasons are two fold - this avoids the need to await for the active stream detail property in the StreamOrchestrator and it also helps our future request for the StreamingScreen to perform the `connect/subscribe` call by itself.
