### PR TITLE
Video freezing when switching orientation from portrait to landscape and vice versa

### DIFF
--- a/Sources/DolbyIORTSUIKit/Private/Models/StreamSourceAndViewRenderers.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Models/StreamSourceAndViewRenderers.swift
@@ -6,14 +6,17 @@ import DolbyIORTSCore
 import Foundation
 
 final class ViewRendererProvider: ObservableObject {
-    private var rendererDictionary: [UUID: StreamSourceViewRenderer] = [:]
+    
+    private var rendererDictionary: [String: StreamSourceViewRenderer] = [:]
 
-    func renderer(for source: StreamSource) -> StreamSourceViewRenderer {
-        if let renderer = rendererDictionary[source.id] {
+    func renderer(for source: StreamSource, isPortait: Bool) -> StreamSourceViewRenderer {
+        let orientationKey = isPortait ? "Portrait" : "Landscape"
+        let storageKey = "\(source.id)_\(orientationKey)"
+        if let renderer = rendererDictionary[storageKey] {
             return renderer
         } else {
             let renderer = StreamSourceViewRenderer(source)
-            rendererDictionary[source.id] = renderer
+            rendererDictionary[storageKey] = renderer
             return renderer
         }
     }

--- a/Sources/DolbyIORTSUIKit/Private/Views/GridView/GridView.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Views/GridView/GridView.swift
@@ -73,7 +73,7 @@ struct GridView: View {
                     
                     VideoRendererView(
                         viewModel: viewModel,
-                        viewRenderer: viewRendererProvider.renderer(for: viewModel.streamSource),
+                        viewRenderer: viewRendererProvider.renderer(for: viewModel.streamSource, isPortait: deviceOrientation.isPortrait),
                         maxWidth: maxAllowedSubVideoWidth,
                         maxHeight: maxAllowedSubVideoHeight,
                         contentMode: .aspectFit
@@ -96,7 +96,7 @@ struct GridView: View {
                 ForEach(viewModel.allVideoViewModels, id: \.streamSource.id) { viewModel in
                     VideoRendererView(
                         viewModel: viewModel,
-                        viewRenderer: viewRendererProvider.renderer(for: viewModel.streamSource),
+                        viewRenderer: viewRendererProvider.renderer(for: viewModel.streamSource, isPortait: deviceOrientation.isPortrait),
                         maxWidth: .infinity,
                         maxHeight: availableHeight / CGFloat(rowsCount),
                         contentMode: .aspectFit

--- a/Sources/DolbyIORTSUIKit/Private/Views/ListView/ListView.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Views/ListView/ListView.swift
@@ -210,7 +210,7 @@ struct ListView: View {
         let viewModel = viewModel.primaryVideoViewModel
         return VideoRendererView(
             viewModel: viewModel,
-            viewRenderer: mainViewRendererProvider.renderer(for: viewModel.streamSource),
+            viewRenderer: mainViewRendererProvider.renderer(for: viewModel.streamSource, isPortait: deviceOrientation.isPortrait),
             maxWidth: maxAllowedMainVideoSize.width,
             maxHeight: maxAllowedMainVideoSize.height,
             contentMode: .aspectFit
@@ -227,7 +227,7 @@ struct ListView: View {
 
             VideoRendererView(
                 viewModel: viewModel,
-                viewRenderer: thumbnailViewRendererProvider.renderer(for: viewModel.streamSource),
+                viewRenderer: thumbnailViewRendererProvider.renderer(for: viewModel.streamSource, isPortait: deviceOrientation.isPortrait),
                 maxWidth: maxAllowedSubVideoWidth,
                 maxHeight: maxAllowedSubVideoHeight,
                 contentMode: .aspectFit
@@ -257,7 +257,7 @@ struct ListView: View {
             ForEach(viewModel.secondaryVideoViewModels, id: \.streamSource.id) { viewModel in
                 VideoRendererView(
                     viewModel: viewModel,
-                    viewRenderer: thumbnailViewRendererProvider.renderer(for: viewModel.streamSource),
+                    viewRenderer: thumbnailViewRendererProvider.renderer(for: viewModel.streamSource, isPortait: deviceOrientation.isPortrait),
                     maxWidth: .infinity,
                     maxHeight: availableHeight,
                     contentMode: .aspectFit

--- a/Sources/DolbyIORTSUIKit/Private/Views/SingleStream/SingleStreamView.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Views/SingleStream/SingleStreamView.swift
@@ -23,6 +23,8 @@ struct SingleStreamView: View {
     @State private var selectedVideoStreamSourceId: UUID
     @State private var isShowingSettingsScreen: Bool = false
     @State private var isShowingStatsInfoScreen: Bool = false
+    @State private var deviceOrientation: UIDeviceOrientation = UIDeviceOrientation.portrait
+
     @StateObject private var userInteractionViewModel: UserInteractionViewModel = .init()
     @StateObject private var viewRendererProvider: ViewRendererProvider = .init()
 
@@ -100,7 +102,7 @@ struct SingleStreamView: View {
                         let maxAllowedVideoHeight = proxy.size.height
                         VideoRendererView(
                             viewModel: videoRendererViewModel,
-                            viewRenderer: viewRendererProvider.renderer(for: videoRendererViewModel.streamSource),
+                            viewRenderer: viewRendererProvider.renderer(for: videoRendererViewModel.streamSource, isPortait: deviceOrientation.isPortrait),
                             maxWidth: maxAllowedVideoWidth,
                             maxHeight: maxAllowedVideoHeight,
                             contentMode: .aspectFit
@@ -148,6 +150,11 @@ struct SingleStreamView: View {
                 }
             }
             .navigationBarHidden(isShowingDetailPresentation)
+        }
+        .onRotate { newOrientation in
+            if !newOrientation.isFlat && newOrientation.isValidInterfaceOrientation {
+                deviceOrientation = newOrientation
+            }
         }
     }
     

--- a/Sources/DolbyIORTSUIKit/Public/Screens/Media/StreamingScreen.swift
+++ b/Sources/DolbyIORTSUIKit/Public/Screens/Media/StreamingScreen.swift
@@ -175,6 +175,12 @@ public struct StreamingScreen: View {
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarBackButtonHidden(true)
         }
+        .onAppear {
+            UIApplication.shared.isIdleTimerDisabled = true
+        }
+        .onDisappear {
+            UIApplication.shared.isIdleTimerDisabled = false
+        }
     }
 }
 


### PR DESCRIPTION
## Description:

Use different renderers on portrait and landscape mode to eliminate stopVideo on a renderer thats actively being used.

Disable idle timer when the user is on StreamingScreen.