### PR TITLE
Bugfix/rts core issues

### DIFF
--- a/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
+++ b/Sources/DolbyIORTSCore/Builder/StreamSourceBuilder.swift
@@ -124,7 +124,11 @@ final class StreamSourceBuilder {
         streamingStatistics = statistics
     }
 
-    func build() throws -> StreamSource {
+    func build(isAudioEnabled: Bool) throws -> StreamSource {
+        if isAudioEnabled, hasMissingAudioTrack {
+            throw BuildError.missingAudioTrack
+        }
+
         guard !hasMissingVideoTrack, let videoTrack = videoTrack else {
             throw BuildError.missingVideoTrack
         }

--- a/Sources/DolbyIORTSCore/Model/StreamSource.swift
+++ b/Sources/DolbyIORTSCore/Model/StreamSource.swift
@@ -11,7 +11,7 @@ public struct StreamSource: Equatable, Hashable, Identifiable {
         case main
         case other(sourceId: String)
 
-        init(id: String?) {
+        public init(id: String?) {
             switch id {
             case .none, .some(""):
                 self = .main

--- a/Sources/DolbyIORTSCore/State/State.swift
+++ b/Sources/DolbyIORTSCore/State/State.swift
@@ -75,7 +75,7 @@ struct SubscribedState {
     }
 
     mutating func remove(streamId: String, sourceId: String?) {
-        streamSourceBuilders.removeAll { $0.streamId == streamId && $0.sourceId.value == sourceId }
+        streamSourceBuilders.removeAll { $0.streamId == streamId && $0.sourceId == StreamSource.SourceId(id: sourceId) }
     }
 
     func addAudioTrack(_ track: MCAudioTrack, mid: String) {
@@ -95,23 +95,23 @@ struct SubscribedState {
         builder.addVideoTrack(track, mid: mid)
     }
 
-    mutating func removeBuilder(with sourceId: String?) {
-        guard let indexToRemove = streamSourceBuilders.firstIndex(where: { $0.sourceId.value == sourceId }) else {
+    mutating func removeBuilder(with sourceId: StreamSource.SourceId) {
+        guard let indexToRemove = streamSourceBuilders.firstIndex(where: { $0.sourceId == sourceId }) else {
             return
         }
 
         streamSourceBuilders.remove(at: indexToRemove)
     }
 
-    func setPlayingAudio(_ enable: Bool, for sourceId: String?) {
-        guard let builder = streamSourceBuilders.first(where: { $0.sourceId.value == sourceId }) else {
+    func setPlayingAudio(_ enable: Bool, for sourceId: StreamSource.SourceId) {
+        guard let builder = streamSourceBuilders.first(where: { $0.sourceId == sourceId }) else {
             return
         }
         builder.setPlayingAudio(enable)
     }
 
-    func setPlayingVideo(_ enable: Bool, for sourceId: String?) {
-        guard let builder = streamSourceBuilders.first(where: { $0.sourceId.value == sourceId }) else {
+    func setPlayingVideo(_ enable: Bool, for sourceId: StreamSource.SourceId) {
+        guard let builder = streamSourceBuilders.first(where: { $0.sourceId == sourceId }) else {
             return
         }
         builder.setPlayingVideo(enable)
@@ -125,8 +125,8 @@ struct SubscribedState {
         builder.setAvailableVideoQualityList(list)
     }
     
-    func setSelectedVideoQuality(_ videoQuality: VideoQuality, for sourceId: String?) {
-        guard let builder = streamSourceBuilders.first(where: { $0.sourceId.value == sourceId }) else {
+    func setSelectedVideoQuality(_ videoQuality: VideoQuality, for sourceId: StreamSource.SourceId) {
+        guard let builder = streamSourceBuilders.first(where: { $0.sourceId == sourceId }) else {
             return
         }
         builder.setSelectedVideoQuality(videoQuality)

--- a/Sources/DolbyIORTSCore/State/StateMachine.swift
+++ b/Sources/DolbyIORTSCore/State/StateMachine.swift
@@ -44,7 +44,7 @@ final class StateMachine {
     func setPlayingAudio(_ enable: Bool, for source: StreamSource) {
         switch currentState {
         case let .subscribed(state):
-            state.setPlayingAudio(enable, for: source.sourceId.value)
+            state.setPlayingAudio(enable, for: source.sourceId)
             currentState = .subscribed(state)
         default:
             Self.logger.error("🛑 Unexpected state on setPlayingAudio - \(self.currentState.description)")
@@ -54,7 +54,7 @@ final class StateMachine {
     func setPlayingVideo(_ enable: Bool, for source: StreamSource) {
         switch currentState {
         case let .subscribed(state):
-            state.setPlayingVideo(enable, for: source.sourceId.value)
+            state.setPlayingVideo(enable, for: source.sourceId)
             currentState = .subscribed(state)
         default:
             Self.logger.error("🛑 Unexpected state on setPlayingVideo - \(self.currentState.description)")
@@ -183,7 +183,7 @@ final class StateMachine {
     func selectVideoQuality(_ quality: VideoQuality, for source: StreamSource) {
         switch currentState {
         case let .subscribed(state):
-            state.setSelectedVideoQuality(quality, for: source.sourceId.value)
+            state.setSelectedVideoQuality(quality, for: source.sourceId)
             currentState = .subscribed(state)
         default:
             Self.logger.error("🛑 Unexpected state on selectVideoQuality - \(self.currentState.description)")

--- a/Sources/DolbyIORTSCore/State/StateMachine.swift
+++ b/Sources/DolbyIORTSCore/State/StateMachine.swift
@@ -21,12 +21,15 @@ final class StateMachine {
     lazy var statePublisher: AnyPublisher<State, Never> = stateSubject.eraseToAnyPublisher()
     private(set) var cachedSourceZeroVideoTrackAndMid: VideoTrackAndMid?
     private(set) var cachedSourceZeroAudioTrackAndMid: AudioTrackAndMid?
+    private(set) var configuration: SubscriptionConfiguration
 
     init(initialState: State) {
         currentState = initialState
+        configuration = .init()
     }
 
-    func startConnection(streamName: String, accountID: String) {
+    func startConnection(streamName: String, accountID: String, configuration: SubscriptionConfiguration) {
+        self.configuration = configuration
         currentState = .connecting
     }
 
@@ -77,7 +80,8 @@ final class StateMachine {
         currentState = .subscribed(
             .init(
                 cachedVideoTrackDetail: cachedSourceZeroVideoTrackAndMid,
-                cachedAudioTrackDetail: cachedSourceZeroAudioTrackAndMid
+                cachedAudioTrackDetail: cachedSourceZeroAudioTrackAndMid,
+                configuration: configuration
             )
         )
         cachedSourceZeroAudioTrackAndMid = nil

--- a/Sources/DolbyIORTSCore/StreamOrchestrator.swift
+++ b/Sources/DolbyIORTSCore/StreamOrchestrator.swift
@@ -58,7 +58,11 @@ public final actor StreamOrchestrator {
         Self.logger.debug("👮‍♂️ Start subscribe")
         logHandler.setLogFilePath(filePath: configuration.sdkLogPath)
         
-        async let startConnectionStateUpdate: Void = stateMachine.startConnection(streamName: streamName, accountID: accountID)
+        async let startConnectionStateUpdate: Void = stateMachine.startConnection(
+            streamName: streamName,
+            accountID: accountID,
+            configuration: configuration
+        )
         async let startConnection = subscriptionManager.connect(streamName: streamName, accountID: accountID, configuration: configuration)
         
         let (_, connectionResult) = await (startConnectionStateUpdate, startConnection)

--- a/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -426,7 +426,7 @@ final class StreamViewModel: ObservableObject {
             // Use audio from the video source, if no audio track uses the last one used or just the 1st one
             selectedAudioSource = selectedVideoSource.audioTracksCount > 0 ? selectedVideoSource : internalState.selectedAudioSource
         case let .source(sourceId: sourceId):
-            selectedAudioSource = sourcesWithAudio.first(where: { $0.sourceId.value == sourceId }) ?? sourcesWithAudio[0]
+            selectedAudioSource = sourcesWithAudio.first(where: { $0.sourceId == StreamSource.SourceId(id: sourceId) }) ?? sourcesWithAudio[0]
         }
         return selectedAudioSource
     }

--- a/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
+++ b/Sources/DolbyIORTSUIKit/Private/ViewModels/StreamViewModel.swift
@@ -309,7 +309,7 @@ final class StreamViewModel: ObservableObject {
             selectedVideoSource = sources.first { $0.id == currentlySelectedVideoSource.id } ?? sortedSources[0]
         }
 
-        let selectedAudioSource = audioSelection(from: sortedSources, settings: settings, selectedVideoSource: selectedVideoSource)
+        let selectedAudioSource = audioSelection(from: sources, settings: settings, selectedVideoSource: selectedVideoSource)
 
         let displayMode: DisplayMode
         switch settings.multiviewLayout {


### PR DESCRIPTION
Description:

Fix the below issues:
1. Making audio tracks mandatory before source playback
2. Compare sourceid object instead of value comparison as `main` sources now arrive as empty string instead of nil
3. Audio selection function has to use unsorted sources at all times as connection order is vital for picking the right audio track