### PR TITLE
Remove redundant seconds to milliseconds conversion 

### DIFF
--- a/Sources/DolbyIORTSUIKit/Private/Views/StatsInfo/StatsInfoViewModel.swift
+++ b/Sources/DolbyIORTSUIKit/Private/Views/StatsInfo/StatsInfoViewModel.swift
@@ -134,7 +134,7 @@ final class StatsInfoViewModel: ObservableObject {
             result.append(
                 StatData(
                     key: String(localized: "stream.stats.audio-jitter.label", bundle: .module),
-                    value: "\(Int(audioJitter * 1000)) ms"
+                    value: "\(audioJitter) ms"
                 )
             )
         }


### PR DESCRIPTION
Remove redundant seconds to milliseconds conversion of audio jitter as it's already converted at the time of parsing